### PR TITLE
Extending Prefix Heuristics

### DIFF
--- a/LinearIndexedGrammar/Program.cs
+++ b/LinearIndexedGrammar/Program.cs
@@ -50,6 +50,34 @@ namespace LinearIndexedGrammar
                 RunProgram(programParams);
         }
 
+        private static void OldMain(string[] args)
+        {
+            var vocabularyFilename = "Vocabulary.json";
+            var grammarFileName = "CFG.txt";
+            var sentence = "David knows the man kissed the woman a girl";
+
+            var universalVocabulary = Vocabulary.ReadVocabularyFromFile(vocabularyFilename);
+            ContextFreeGrammar.PartsOfSpeech = universalVocabulary.POSWithPossibleWords.Keys
+                .Select(x => new SyntacticCategory(x)).ToHashSet();
+
+            var rules = GrammarFileReader.ReadRulesFromFile(grammarFileName);
+            var cfGrammar = new ContextFreeGrammar(rules);
+
+            var parser = new EarleyParser(cfGrammar, universalVocabulary);
+            var b = parser.ParseSentence(sentence.Split());
+            var k = parser.SuggestRHSForCompletion();
+
+            var rule = new Rule("VP", k);
+            rules.Add(rule);
+            cfGrammar = new ContextFreeGrammar(rules);
+
+            parser = new EarleyParser(cfGrammar, universalVocabulary);
+            b = parser.ParseSentence(sentence.Split());
+            k = parser.SuggestRHSForCompletion();
+
+
+
+        }
         private static void Main(string[] args)
         {
             var maxNonTerminals = 6;
@@ -374,31 +402,6 @@ namespace LinearIndexedGrammar
 
                 (currentGrammar, currentValue) = LearnGrammarFromDataUpToLengthN(data, dataVocabulary,
                     currentWordLength, minWordsInSentences, progParams, initialGrammars[currentWordLength]);
-                //SEFI
-                //LogManager.GetCurrentClassLogger().Info($"End of learning word Length { currentWordLength}, \r\n Current Grammar {currentGrammar} \r\n CurrentValue { currentValue}");
-
-                /*
-                //what if you did not converge on a grammar that generates the data precisely?
-                if (currentValue < 1)
-                {
-                    //backtrack to initial word length and retry?
-                    if (successfulGrammars.Any())
-                    {
-                        LogManager.GetCurrentClassLogger().Info("retrying from previous successful grammar");
-                        currentGrammar = successfulGrammars.Dequeue();
-                        LogManager.GetCurrentClassLogger().Info($"the initial grammar is: {currentGrammar}");
-                        currentWordLength--;
-
-                    }
-                    else
-                    {
-                        LogManager.GetCurrentClassLogger().Info("retrying from scratch");
-                        currentWordLength = initialWordLength - 1;
-                    }
-                }
-                else
-                    successfulGrammars.Enqueue(currentGrammar);
-                */
                 currentWordLength++;
                 if (currentWordLength <= maxSentenceLength)
                     initialGrammars[currentWordLength] = currentGrammar;

--- a/LinearIndexedGrammar/Properties/launchSettings.json
+++ b/LinearIndexedGrammar/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "LinearIndexedGrammar": {
       "commandName": "Project",
-      "commandLineArgs": "FileName: \"NightRunFullAllCFGDistsSingleVerbalCategory.json\""
+      "commandLineArgs": "FileName: \"NightRunFullAllCFGDists.json\""
     }
   }
 }

--- a/LinearIndexedGrammarLearner/SimulatedAnnealing.cs
+++ b/LinearIndexedGrammarLearner/SimulatedAnnealing.cs
@@ -237,9 +237,8 @@ namespace LinearIndexedGrammarLearner
             int randomPastBestGrammar = 0;
             while (currentIteration++ < _params.NumberOfIterations)
             {
-                LogManager.GetCurrentClassLogger().Info($"iteration {currentIteration}, probability {currentValue}");
-               
                 (currentGrammar, currentValue, feasible) = RunSingleIteration(currentGrammar, currentValue);
+                LogManager.GetCurrentClassLogger().Info($"iteration {currentIteration}, probability {currentValue} (feasible: {feasible})");
 
                 if (_objectiveFunction.IsMaximalValue(currentValue))
                 {

--- a/LinearIndexedGrammarParser/GrammarFileReader.cs
+++ b/LinearIndexedGrammarParser/GrammarFileReader.cs
@@ -8,31 +8,7 @@ namespace LinearIndexedGrammarParser
 {
     public class GrammarFileReader
     {
-        /* old version
-        public static (string[][] sentences, HashSet<string> POSCategoriesInData) GetSentencesInWordLengthRange(
-          string[][] allData, Vocabulary dataVocabulary, int minWords, int maxWords)
-        {
-            var sentences = new List<string[]>();
-            var posCategories = new HashSet<string>();
-
-            foreach (var arr in allData)
-            {
-                if (arr.Length > maxWords || arr.Length < minWords) continue;
-
-                var sentence = new string[arr.Length];
-                for (var i = 0; i < sentence.Length; i++)
-                {
-                    var possiblePOS = dataVocabulary.WordWithPossiblePOS[arr[i]];
-                    foreach (var pos in possiblePOS)
-                        posCategories.Add(pos);
-                }
-
-                sentences.Add(arr);
-            }
-
-            return (sentences.ToArray(), posCategories);
-        }
-        */
+       
         public static string[][] GetSentencesInWordLengthRange(
             string[][] allData, int minWords, int maxWords)
         {
@@ -65,21 +41,22 @@ namespace LinearIndexedGrammarParser
             return (statesList, rules);
         }
 
-        //public static List<EarleyState> ParseSentenceAccordingToGrammar(string filename, string vocabularyFilename,
-        //    string sentence)
-        //{
-        //    var universalVocabulary = Vocabulary.ReadVocabularyFromFile(vocabularyFilename);
-        //    ContextFreeGrammar.PartsOfSpeech = universalVocabulary.POSWithPossibleWords.Keys
-        //        .Select(x => new SyntacticCategory(x)).ToHashSet();
+        public static List<EarleyState> ParseSentenceAccordingToGrammar(string filename, string vocabularyFilename,
+            string sentence)
+        {
+            var universalVocabulary = Vocabulary.ReadVocabularyFromFile(vocabularyFilename);
+            ContextFreeGrammar.PartsOfSpeech = universalVocabulary.POSWithPossibleWords.Keys
+                .Select(x => new SyntacticCategory(x)).ToHashSet();
 
-        //    var rules = ReadRulesFromFile(filename);
-        //    var cfGrammar = new ContextFreeGrammar(rules);
+            var rules = ReadRulesFromFile(filename);
+            var cfGrammar = new ContextFreeGrammar(rules);
 
-        //    var parser = new EarleyParser(cfGrammar, universalVocabulary);
+            var parser = new EarleyParser(cfGrammar, universalVocabulary);
 
-        //    var n = parser.ParseSentence(sentence.Split());
-        //    return n;
-        //}
+            var n = parser.ParseSentence(sentence.Split());
+
+            return parser.GetGammaStates();
+        }
 
 
         private static DerivedCategory CreateDerivedCategory(string s)

--- a/LinearIndexedGrammarParser/RuleSpace.cs
+++ b/LinearIndexedGrammarParser/RuleSpace.cs
@@ -55,6 +55,8 @@ namespace LinearIndexedGrammarParser
             var numberOfPossibleRHS = length * length;
 
             //allocating the first column of CFG, push and pop rule tables.
+            //there are numberOfPossibleRHS - length + 1 unique combinations 
+            //(numberOfPossibleRHS includes counting twice POS1*POS1, POS2*POS2 etc)
             _ruleSpace[RuleType.CFGRules][0] = new Rule[numberOfPossibleRHS - length + 1];
             _ruleSpace[RuleType.Push1Rules][0] = new Rule[numberOfPossibleRHS - length + 1];
             _ruleSpace[RuleType.PopRules][0] = new Rule[1];

--- a/LinearIndexedGrammarParserTests/ParserTests.cs
+++ b/LinearIndexedGrammarParserTests/ParserTests.cs
@@ -3,18 +3,19 @@ using Newtonsoft.Json;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace LinearIndexedGrammarParserTests
 {
     public class ParserTests
     {
-        /*
-        public ParserTests(ITestOutputHelper output)
-        {
-            this.output = output;
-        }
+        
+        //public ParserTests(ITestOutputHelper output)
+        //{
+        //    this.output = output;
+        //}
 
-        private readonly ITestOutputHelper output;
+        //private readonly ITestOutputHelper output;
 
         [Fact]
         public void CFGLeftRecursionTest()
@@ -49,17 +50,20 @@ namespace LinearIndexedGrammarParserTests
         {
             var n = GrammarFileReader.ParseSentenceAccordingToGrammar("CFG.txt", "Vocabulary.json",
                 "David knows the man kissed the woman a girl");
+
+
             var settings = new JsonSerializerSettings
             {
-                Formatting = Formatting.Indented, NullValueHandling = NullValueHandling.Ignore,
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+
             };
-            var actual = JsonConvert.SerializeObject(n, settings);
+            var actual = JsonConvert.SerializeObject(n, Formatting.Indented, settings);
             var expected = File.ReadAllText(@"ExpectedCFG.json");
             Assert.Equal(expected, actual);
         }
 
-        
+        /*
         [Fact]
         public void LIGMovementFromDirectObjectTest()
         {


### PR DESCRIPTION
Making use of the prefix valid property of an Earley Parser, 
if a sentence is not fully parsed, try to extend the currently parsed prefix by suggestion a rule with a corresponding RHS such that it will parse the next word.